### PR TITLE
SonyDevice: Support 2010 Blu-ray players, e.g. BDP-S370

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
         - pip install -r test_requirements.txt
         - pip install .
       name: "Linting with pylint"
-      script: find sonyapilib -name \*.py -exec pylint {} +
+      script: find sonyapilib -name \*.py -exec pylint -d C0302 {} +
     - stage: linting
       install: pip install pyflakes
       name: "Linting with pyflakes"

--- a/sonyapilib/device.py
+++ b/sonyapilib/device.py
@@ -44,6 +44,8 @@ class HttpMethod(Enum):
 
 
 class IrccCategory(Enum):
+    """Device categories used by IRCC."""
+
     TV1 = 1
     AUSYS3 = 80
     TV1EEE = 119

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -812,6 +812,7 @@ class SonyDeviceTest(unittest.TestCase):
         """Create a new device instance"""
         sonyapilib.device.TIMEOUT = 0.1
         device = SonyDevice("test", "test")
+        device.api_version = 3
         device.cookies = jsonpickle.decode(read_file("data/cookies.json"))
         return device
 

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -399,6 +399,13 @@ class SonyDeviceTest(unittest.TestCase):
         device._update_commands()
         self.assertEqual(mock_parse_cmd_list.call_count, 1)
 
+    @mock.patch('sonyapilib.device.SonyDevice._use_builtin_command_list', side_effect=mock_nothing)
+    def test_update_commands_v0(self, mock_parse_cmd_list):
+        device = self.create_device()
+        device.api_version = 0
+        device._update_commands()
+        self.assertEqual(mock_parse_cmd_list.call_count, 1)
+
     @mock.patch('sonyapilib.device.SonyDevice._parse_command_list', side_effect=mock_nothing)
     def test_update_commands_v3(self, mock_parse_cmd_list):
         device = self.create_device()


### PR DESCRIPTION
After your feedback in https://github.com/alexmohr/sonyapilib/issues/57, I decided to spend some more time with my old Blu-ray player. I analyzed another application to understand how Sony encodes IRCC commands. That allowed me to use IR key codes instead of fixed base64 encoded strings, and to prepare for other types of old devices. The IR key codes match the codes of my RMT-B107P remote control. There are three additional codes (Karaoke, Netflix and Mode3D), which my device doesn't know. But because they don't conflict and were present in tests/data/getRemoteCommandList.xml, I decided to include them. Maybe they become useful for another device. My device understands discrete PowerOn (46) and PowerOff (47), but I didn't include them, because using them over HTTP doesn't seem to make sense. If other devices are reachable during stand-by, these codes could be added later.

With this patch applied, I can finally control my BDP-S370. Though I haven't tried it together with your Home Assistant integration, yet.