### PR TITLE
Fix pylint warning `unspecified-encoding`

### DIFF
--- a/examples/convert_to_hass.py
+++ b/examples/convert_to_hass.py
@@ -5,7 +5,7 @@ from sonyapilib.device import SonyDevice
 
 config_file = 'bluray.json'
 
-with open(config_file, 'r') as myfile:
+with open(config_file, 'r', encoding='utf-8') as myfile:
     data = myfile.read()
 
 device = SonyDevice.load_from_json(data)
@@ -13,4 +13,4 @@ device = SonyDevice.load_from_json(data)
 hass_cfg = {}
 hass_cfg[device.host] = {}
 hass_cfg[device.host]["device"] = data
-print(json.dumps(hass_cfg), file=open("sony.conf", "w"))
+print(json.dumps(hass_cfg), file=open("sony.conf", "w", encoding="utf-8"))

--- a/examples/pair_and_apps.py
+++ b/examples/pair_and_apps.py
@@ -7,9 +7,8 @@ CONFIG_FILE = "bluray.json"
 def save_device():
     """Save the device to disk."""
     data = device.save_to_json()
-    text_file = open(CONFIG_FILE, "w")
-    text_file.write(data)
-    text_file.close()
+    with open(CONFIG_FILE, "w", encoding="utf-8") as text_file:
+        text_file.write(data)
 
 
 def load_device():
@@ -17,7 +16,7 @@ def load_device():
     import os
     sony_device = None
     if os.path.exists(CONFIG_FILE):
-        with open(CONFIG_FILE, 'r') as content_file:
+        with open(CONFIG_FILE, 'r', encoding='utf-8') as content_file:
             json_data = content_file.read()
             sony_device = SonyDevice.load_from_json(json_data)
     return sony_device


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning unspecified-encoding.
"It is better to specify an encoding when opening documents. Using the system default implicitly can create problems on other operating systems. See [https://peps.python.org/pep-0597/](https://peps.python.org/pep-0597/)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.